### PR TITLE
v0.17.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.16.4" %}
+{% set version = "0.17.4" %}
 
 package:
   name: lief
@@ -6,10 +6,10 @@ package:
 
 source:
   - url: https://github.com/lief-project/LIEF/archive/{{ version }}.tar.gz
-    sha256: 311fff5ea9ecbe57b8d02e68739b97673cb14763129ce53af3eac8fee6bf845e
+    sha256: cc1c8c563faaddf497d1a2d8f2712257f15e680e6a5ef4ea1e29ba8e19fb6248
 
 build:
-  number: 1
+  number: 0
 
 requirements:
   build:


### PR DESCRIPTION
py-lief v0.17.4

**Destination channel:**  defaults

### Links

- [PKG-12693](https://anaconda.atlassian.net/browse/PKG-12693) 
- [Upstream repository](https://github.com/lief-project/LIEF/tree/0.17.4)
- [Upstream changelog/diff](https://lief.re/doc/stable/changelog.html#february-21th-2026)

### Explanation of changes:

- Bump version and SHA


[PKG-12693]: https://anaconda.atlassian.net/browse/PKG-12693?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ